### PR TITLE
fix: Fix emoji picker mask issue.

### DIFF
--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -4,6 +4,8 @@
   padding: 40px 0 0 0;
   flex-grow: 0;
   opacity: .5;
+  position: relative;
+  z-index: -1;
 
   &__inner {
     display: flex;

--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -7,6 +7,7 @@
     text-align: center;
     position: relative;
     margin: 100px 0 20px;
+    z-index: -1;
 
     &-h {
       text-align: center;


### PR DESCRIPTION
通过对 `footer` 以及 `pagination` class 添加 `z-index: -1;` 来实现表情挑选器对页面元素的遮罩效果。
解决 issue #22 中提到的问题。

效果如下：

![image](https://github.com/user-attachments/assets/05849db6-719a-4563-be62-c8b81ff9e513)
