### PR TITLE
fix: 修复文章数量显示逻辑 #25

### DIFF
--- a/templates/category.html
+++ b/templates/category.html
@@ -8,7 +8,7 @@
       <div class="post">
         <h1
           class="post-title"
-          th:text="'分类：'+${category.spec.displayName}+' ('+${category.status.visiblePostCount}+' 篇文章)'"
+          th:text="'分类：'+${category.spec.displayName}+' ('+${category.status.visiblePostCount?:0}+' 篇文章)'"
         >
           分类：分类名 (n 篇文章)
         </h1>

--- a/templates/modules/category-tree.html
+++ b/templates/modules/category-tree.html
@@ -1,7 +1,7 @@
 <ul th:fragment="next (categories)">
   <li th:fragment="single (categories)" th:each="category : ${categories}">
     <a th:href="@{${category.status.permalink}}">
-      <span th:text="${category.spec.displayName}+' ('+${category.status.visiblePostCount}+' 篇文章)'"> </span>
+      <span th:text="${category.spec.displayName}+' ('+${category.status.visiblePostCount?:0}+' 篇文章)'"> </span>
     </a>
     <th:block th:if="${not #lists.isEmpty(category.children)}">
       <th:block th:replace="~{modules/category-tree :: next (categories=${category.children})}"></th:block>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -8,7 +8,7 @@
       <div class="post">
         <h1
           class="post-title"
-          th:text="'标签：'+${tag.spec.displayName}+' ('+${tag.status.visiblePostCount}+' 篇文章)'"
+          th:text="'标签：'+${tag.spec.displayName}+' ('+${tag.status.visiblePostCount?:0}+' 篇文章)'"
         >
           标签：标签名 (n 篇文章)
         </h1>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -11,7 +11,7 @@
           <li th:each="tag: ${tags}" class="tag-list">
             <a
               th:href="@{${tag.status.permalink}}"
-              th:text="${tag.spec.displayName}+' ('+${tag.status.visiblePostCount}+' 篇文章)'"
+              th:text="${tag.spec.displayName}+' ('+${tag.status.visiblePostCount?:0}+' 篇文章)'"
             >
               标签名 (n 篇文章)
             </a>


### PR DESCRIPTION
- 在分类和标签相关的模板中，使用 Elvis 操作符（?:）来处理可见文章数量
- 当 visiblePostCount 为 null 时，显示为 0，避免出现空白或错误的数字
- 修改涉及 category.html、category-tree.html、tag.html 和 tags.html 四个模板文件

关联Issues: #25