### PR TITLE
fix: 修复未按照当前页面显示对应标题问题

### DIFF
--- a/i18n/default.properties
+++ b/i18n/default.properties
@@ -1,0 +1,55 @@
+common.previousPage=Previous
+common.nextPage=Next
+common.more=More
+common.all=All
+common.noPosts=No Posts
+common.comment=Comment
+common.edit=Edit
+common.publishedOn=Published on {0}
+common.visitCount={0} Visits
+
+widget.categories.title=Categories
+widget.popularPosts.title=Popular Posts
+widget.tags.title=Tags
+widget.latestComments.title=Latest Comments
+widget.profile.postCount.label=Posts
+widget.profile.categoryCount.label=Categories
+widget.profile.commentCount.label=Comments
+widget.profile.visitCount.label=Visits
+
+page.archives.title=Archives
+page.archives.date={0} / {1}
+page.links.title=Links
+page.moments.title=Moments
+page.photos.title=Photos
+page.tags.title=Tags
+page.tags.morePosts=More Posts
+page.tag.title=Tag: {0}
+page.categories.title=Categories
+page.category.title=Category: {0}
+page.author.title=Author: {0}
+page.error.backToHome=Back to Home
+page.post.toc=Table of Contents
+
+fragment.header.search=Search
+fragment.header.menu=Menu
+fragment.header.console=Console
+fragment.header.logout=Logout
+fragment.header.login=Login
+fragment.layout.toTop=Back to Top
+fragment.tagFilter.allTags=All Tags
+fragment.shareModal.title=Share
+fragment.shareModal.copy=Copy
+fragment.shareModal.copied=Copied
+fragment.postCard.pinned=Pinned
+
+jsModule.colorSchemeSwitcher.dark=Dark
+jsModule.colorSchemeSwitcher.light=Light
+jsModule.colorSchemeSwitcher.auto=Auto
+jsModule.share.qzone=QQ Zone
+jsModule.share.weibo=Weibo
+jsModule.share.douban=Douban
+jsModule.share.wechat=WeChat
+jsModule.share.native=System
+jsModule.share.windowTitle=Share
+jsModule.upvote.networkError=Network request failed, please try again later

--- a/i18n/default.properties
+++ b/i18n/default.properties
@@ -1,55 +1,7 @@
-common.previousPage=Previous
-common.nextPage=Next
-common.more=More
-common.all=All
-common.noPosts=No Posts
-common.comment=Comment
-common.edit=Edit
-common.publishedOn=Published on {0}
-common.visitCount={0} Visits
-
-widget.categories.title=Categories
-widget.popularPosts.title=Popular Posts
-widget.tags.title=Tags
-widget.latestComments.title=Latest Comments
-widget.profile.postCount.label=Posts
-widget.profile.categoryCount.label=Categories
-widget.profile.commentCount.label=Comments
-widget.profile.visitCount.label=Visits
-
 page.archives.title=Archives
-page.archives.date={0} / {1}
 page.links.title=Links
 page.moments.title=Moments
-page.photos.title=Photos
 page.tags.title=Tags
-page.tags.morePosts=More Posts
 page.tag.title=Tag: {0}
 page.categories.title=Categories
 page.category.title=Category: {0}
-page.author.title=Author: {0}
-page.error.backToHome=Back to Home
-page.post.toc=Table of Contents
-
-fragment.header.search=Search
-fragment.header.menu=Menu
-fragment.header.console=Console
-fragment.header.logout=Logout
-fragment.header.login=Login
-fragment.layout.toTop=Back to Top
-fragment.tagFilter.allTags=All Tags
-fragment.shareModal.title=Share
-fragment.shareModal.copy=Copy
-fragment.shareModal.copied=Copied
-fragment.postCard.pinned=Pinned
-
-jsModule.colorSchemeSwitcher.dark=Dark
-jsModule.colorSchemeSwitcher.light=Light
-jsModule.colorSchemeSwitcher.auto=Auto
-jsModule.share.qzone=QQ Zone
-jsModule.share.weibo=Weibo
-jsModule.share.douban=Douban
-jsModule.share.wechat=WeChat
-jsModule.share.native=System
-jsModule.share.windowTitle=Share
-jsModule.upvote.networkError=Network request failed, please try again later

--- a/i18n/es.properties
+++ b/i18n/es.properties
@@ -1,0 +1,55 @@
+common.previousPage=Página Anterior
+common.nextPage=Página Siguiente
+common.more=Más
+common.all=Todo
+common.noPosts=No hay Publicaciones
+common.comment=Comentario
+common.edit=Editar
+common.publishedOn=Publicado el {0}
+common.visitCount={0} Lecturas
+
+widget.categories.title=Categorías
+widget.popularPosts.title=Publicaciones Populares
+widget.tags.title=Etiquetas
+widget.latestComments.title=Últimos Comentarios
+widget.profile.postCount.label=Número de Publicaciones
+widget.profile.categoryCount.label=Número de Categorías
+widget.profile.commentCount.label=Número de Comentarios
+widget.profile.visitCount.label=Visitas
+
+page.archives.title=Archivos
+page.archives.date=Año {0} Mes {1}
+page.links.title=Enlaces
+page.moments.title=Momentos
+page.photos.title=Galería
+page.tags.title=Etiquetas
+page.tags.morePosts=Más Publicaciones
+page.tag.title=Etiqueta: {0}
+page.categories.title=Categorías
+page.category.title=Categoría: {0}
+page.author.title=Autor: {0}
+page.error.backToHome=Volver al Inicio
+page.post.toc=Tabla de Contenidos
+
+fragment.header.search=Buscar
+fragment.header.menu=Menú
+fragment.header.console=Consola
+fragment.header.logout=Cerrar Sesión
+fragment.header.login=Iniciar Sesión
+fragment.layout.toTop=Volver Arriba
+fragment.tagFilter.allTags=Todas las Etiquetas
+fragment.shareModal.title=Compartir
+fragment.shareModal.copy=Copiar
+fragment.shareModal.copied=Copiado
+fragment.postCard.pinned=Fijado
+
+jsModule.colorSchemeSwitcher.dark=Oscuro
+jsModule.colorSchemeSwitcher.light=Claro
+jsModule.colorSchemeSwitcher.auto=Seguir Sistema
+jsModule.share.qzone=QQ Zona
+jsModule.share.weibo=Weibo
+jsModule.share.douban=Douban
+jsModule.share.wechat=WeChat
+jsModule.share.native=Compartir del Sistema
+jsModule.share.windowTitle=Compartir
+jsModule.upvote.networkError=Error de red, por favor intente nuevamente más tarde

--- a/i18n/es.properties
+++ b/i18n/es.properties
@@ -1,55 +1,7 @@
-common.previousPage=Página Anterior
-common.nextPage=Página Siguiente
-common.more=Más
-common.all=Todo
-common.noPosts=No hay Publicaciones
-common.comment=Comentario
-common.edit=Editar
-common.publishedOn=Publicado el {0}
-common.visitCount={0} Lecturas
-
-widget.categories.title=Categorías
-widget.popularPosts.title=Publicaciones Populares
-widget.tags.title=Etiquetas
-widget.latestComments.title=Últimos Comentarios
-widget.profile.postCount.label=Número de Publicaciones
-widget.profile.categoryCount.label=Número de Categorías
-widget.profile.commentCount.label=Número de Comentarios
-widget.profile.visitCount.label=Visitas
-
 page.archives.title=Archivos
-page.archives.date=Año {0} Mes {1}
 page.links.title=Enlaces
 page.moments.title=Momentos
-page.photos.title=Galería
 page.tags.title=Etiquetas
-page.tags.morePosts=Más Publicaciones
 page.tag.title=Etiqueta: {0}
 page.categories.title=Categorías
 page.category.title=Categoría: {0}
-page.author.title=Autor: {0}
-page.error.backToHome=Volver al Inicio
-page.post.toc=Tabla de Contenidos
-
-fragment.header.search=Buscar
-fragment.header.menu=Menú
-fragment.header.console=Consola
-fragment.header.logout=Cerrar Sesión
-fragment.header.login=Iniciar Sesión
-fragment.layout.toTop=Volver Arriba
-fragment.tagFilter.allTags=Todas las Etiquetas
-fragment.shareModal.title=Compartir
-fragment.shareModal.copy=Copiar
-fragment.shareModal.copied=Copiado
-fragment.postCard.pinned=Fijado
-
-jsModule.colorSchemeSwitcher.dark=Oscuro
-jsModule.colorSchemeSwitcher.light=Claro
-jsModule.colorSchemeSwitcher.auto=Seguir Sistema
-jsModule.share.qzone=QQ Zona
-jsModule.share.weibo=Weibo
-jsModule.share.douban=Douban
-jsModule.share.wechat=WeChat
-jsModule.share.native=Compartir del Sistema
-jsModule.share.windowTitle=Compartir
-jsModule.upvote.networkError=Error de red, por favor intente nuevamente más tarde

--- a/i18n/zh_CN.properties
+++ b/i18n/zh_CN.properties
@@ -1,0 +1,55 @@
+common.previousPage=上一页
+common.nextPage=下一页
+common.more=更多
+common.all=全部
+common.noPosts=没有文章
+common.comment=评论
+common.edit=编辑
+common.publishedOn=发布于 {0}
+common.visitCount={0} 阅读
+
+widget.categories.title=分类目录
+widget.popularPosts.title=热门文章
+widget.tags.title=标签
+widget.latestComments.title=最新评论
+widget.profile.postCount.label=文章数
+widget.profile.categoryCount.label=分类数
+widget.profile.commentCount.label=评论数
+widget.profile.visitCount.label=访问量
+
+page.archives.title=归档
+page.archives.date={0} 年 {1} 月
+page.links.title=链接
+page.moments.title=瞬间
+page.photos.title=图库
+page.tags.title=标签
+page.tags.morePosts=更多文章
+page.tag.title=标签：{0}
+page.categories.title=分类
+page.category.title=分类：{0}
+page.author.title=作者：{0}
+page.error.backToHome=返回首页
+page.post.toc=目录
+
+fragment.header.search=搜索
+fragment.header.menu=菜单
+fragment.header.console=控制台
+fragment.header.logout=退出登录
+fragment.header.login=登录
+fragment.layout.toTop=回到顶部
+fragment.tagFilter.allTags=所有标签
+fragment.shareModal.title=分享
+fragment.shareModal.copy=复制
+fragment.shareModal.copied=已复制
+fragment.postCard.pinned=置顶
+
+jsModule.colorSchemeSwitcher.dark=暗色
+jsModule.colorSchemeSwitcher.light=亮色
+jsModule.colorSchemeSwitcher.auto=跟随系统
+jsModule.share.qzone=QQ 空间
+jsModule.share.weibo=微博
+jsModule.share.douban=豆瓣
+jsModule.share.wechat=微信
+jsModule.share.native=系统分享
+jsModule.share.windowTitle=分享
+jsModule.upvote.networkError=网络请求失败，请稍后再试

--- a/i18n/zh_CN.properties
+++ b/i18n/zh_CN.properties
@@ -1,55 +1,7 @@
-common.previousPage=上一页
-common.nextPage=下一页
-common.more=更多
-common.all=全部
-common.noPosts=没有文章
-common.comment=评论
-common.edit=编辑
-common.publishedOn=发布于 {0}
-common.visitCount={0} 阅读
-
-widget.categories.title=分类目录
-widget.popularPosts.title=热门文章
-widget.tags.title=标签
-widget.latestComments.title=最新评论
-widget.profile.postCount.label=文章数
-widget.profile.categoryCount.label=分类数
-widget.profile.commentCount.label=评论数
-widget.profile.visitCount.label=访问量
-
 page.archives.title=归档
-page.archives.date={0} 年 {1} 月
 page.links.title=链接
 page.moments.title=瞬间
-page.photos.title=图库
 page.tags.title=标签
-page.tags.morePosts=更多文章
 page.tag.title=标签：{0}
 page.categories.title=分类
 page.category.title=分类：{0}
-page.author.title=作者：{0}
-page.error.backToHome=返回首页
-page.post.toc=目录
-
-fragment.header.search=搜索
-fragment.header.menu=菜单
-fragment.header.console=控制台
-fragment.header.logout=退出登录
-fragment.header.login=登录
-fragment.layout.toTop=回到顶部
-fragment.tagFilter.allTags=所有标签
-fragment.shareModal.title=分享
-fragment.shareModal.copy=复制
-fragment.shareModal.copied=已复制
-fragment.postCard.pinned=置顶
-
-jsModule.colorSchemeSwitcher.dark=暗色
-jsModule.colorSchemeSwitcher.light=亮色
-jsModule.colorSchemeSwitcher.auto=跟随系统
-jsModule.share.qzone=QQ 空间
-jsModule.share.weibo=微博
-jsModule.share.douban=豆瓣
-jsModule.share.wechat=微信
-jsModule.share.native=系统分享
-jsModule.share.windowTitle=分享
-jsModule.upvote.networkError=网络请求失败，请稍后再试

--- a/i18n/zh_TW.properties
+++ b/i18n/zh_TW.properties
@@ -1,0 +1,55 @@
+common.previousPage=上一頁
+common.nextPage=下一頁
+common.more=更多
+common.all=全部
+common.noPosts=沒有文章
+common.comment=評論
+common.edit=編輯
+common.publishedOn=發布於 {0}
+common.visitCount={0} 閱讀
+
+widget.categories.title=分類目錄
+widget.popularPosts.title=熱門文章
+widget.tags.title=標籤
+widget.latestComments.title=最新評論
+widget.profile.postCount.label=文章數
+widget.profile.categoryCount.label=分類數
+widget.profile.commentCount.label=評論數
+widget.profile.visitCount.label=訪問量
+
+page.archives.title=歸檔
+page.archives.date={0} 年 {1} 月
+page.links.title=連結
+page.moments.title=瞬間
+page.photos.title=圖庫
+page.tags.title=標籤
+page.tags.morePosts=更多文章
+page.tag.title=標籤：{0}
+page.categories.title=分類
+page.category.title=分類：{0}
+page.author.title=作者：{0}
+page.error.backToHome=返回首頁
+page.post.toc=目錄
+
+fragment.header.search=搜索
+fragment.header.menu=菜單
+fragment.header.console=控制台
+fragment.header.logout=退出登入
+fragment.header.login=登入
+fragment.layout.toTop=回到頂部
+fragment.tagFilter.allTags=所有標籤
+fragment.shareModal.title=分享
+fragment.shareModal.copy=複製
+fragment.shareModal.copied=已複製
+fragment.postCard.pinned=置頂
+
+jsModule.colorSchemeSwitcher.dark=暗色
+jsModule.colorSchemeSwitcher.light=亮色
+jsModule.colorSchemeSwitcher.auto=跟隨系統
+jsModule.share.qzone=QQ 空間
+jsModule.share.weibo=微博
+jsModule.share.douban=豆瓣
+jsModule.share.wechat=微信
+jsModule.share.native=系統分享
+jsModule.share.windowTitle=分享
+jsModule.upvote.networkError=網路請求失敗，請稍後再試

--- a/i18n/zh_TW.properties
+++ b/i18n/zh_TW.properties
@@ -1,55 +1,7 @@
-common.previousPage=上一頁
-common.nextPage=下一頁
-common.more=更多
-common.all=全部
-common.noPosts=沒有文章
-common.comment=評論
-common.edit=編輯
-common.publishedOn=發布於 {0}
-common.visitCount={0} 閱讀
-
-widget.categories.title=分類目錄
-widget.popularPosts.title=熱門文章
-widget.tags.title=標籤
-widget.latestComments.title=最新評論
-widget.profile.postCount.label=文章數
-widget.profile.categoryCount.label=分類數
-widget.profile.commentCount.label=評論數
-widget.profile.visitCount.label=訪問量
-
 page.archives.title=歸檔
-page.archives.date={0} 年 {1} 月
 page.links.title=連結
 page.moments.title=瞬間
-page.photos.title=圖庫
 page.tags.title=標籤
-page.tags.morePosts=更多文章
 page.tag.title=標籤：{0}
 page.categories.title=分類
 page.category.title=分類：{0}
-page.author.title=作者：{0}
-page.error.backToHome=返回首頁
-page.post.toc=目錄
-
-fragment.header.search=搜索
-fragment.header.menu=菜單
-fragment.header.console=控制台
-fragment.header.logout=退出登入
-fragment.header.login=登入
-fragment.layout.toTop=回到頂部
-fragment.tagFilter.allTags=所有標籤
-fragment.shareModal.title=分享
-fragment.shareModal.copy=複製
-fragment.shareModal.copied=已複製
-fragment.postCard.pinned=置頂
-
-jsModule.colorSchemeSwitcher.dark=暗色
-jsModule.colorSchemeSwitcher.light=亮色
-jsModule.colorSchemeSwitcher.auto=跟隨系統
-jsModule.share.qzone=QQ 空間
-jsModule.share.weibo=微博
-jsModule.share.douban=豆瓣
-jsModule.share.wechat=微信
-jsModule.share.native=系統分享
-jsModule.share.windowTitle=分享
-jsModule.upvote.networkError=網路請求失敗，請稍後再試

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.archives.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="content">

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.categories.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="content">
       <div class="post">
         <h1 class="post-title">所有分类</h1>
         <ul>
-          <li th:replace="~{modules/category-tree :: single(categories=${categories})}" />
+          <li th:replace="~{modules/category-tree :: single(categories=${categories})}"></li>
         </ul>
       </div>
     </div>

--- a/templates/category.html
+++ b/templates/category.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.category.title(${category.spec.displayName})} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="content">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = ${site.title}, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="content">

--- a/templates/links.html
+++ b/templates/links.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.links.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <script th:src="@{/assets/libs/pixelit.js}"></script>

--- a/templates/modules/layout.html
+++ b/templates/modules/layout.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en" th:fragment="html (header, content, footer)">
+<html
+  xmlns:th="https://www.thymeleaf.org"
+  th:lang="${#locale.toLanguageTag}" 
+  th:fragment="html (header, content, footer)">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title th:text="${site.title}"></title>
-
+    <title th:text="${title}"></title>
     <th:block th:if="${theme.config.development.enabled}">
       <script type="module" src="http://localhost:5173/@vite/client"></script>
       <script type="module" src="http://localhost:5173/main.ts"></script>

--- a/templates/moments.html
+++ b/templates/moments.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.moments.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = ${singlePage.spec.title} + ' - ' + ${site.title}, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="post">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(title = ${singlePage.spec.title} + ' - ' + ${site.title}, header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |${singlePage.spec.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="post">

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
 xmlns:th="https://www.thymeleaf.org"
-th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+th:replace="~{modules/layout :: html(title = ${post.spec.title} + ' - ' + ${site.title}, header = null, content = ~{::content}, footer = null)}"
 >
 <th:block th:fragment="content">
   <div class="post">

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
 xmlns:th="https://www.thymeleaf.org"
-th:replace="~{modules/layout :: html(title = ${post.spec.title} + ' - ' + ${site.title}, header = null, content = ~{::content}, footer = null)}"
+th:replace="~{modules/layout :: html(title = |${post.spec.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
 <th:block th:fragment="content">
   <div class="post">

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.tag.title(${tag.spec.displayName})} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="content">

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(header = null, content = ~{::content}, footer = null)}"
+  th:replace="~{modules/layout :: html(title = |#{page.tags.title} - ${site.title}|, header = null, content = ~{::content}, footer = null)}"
 >
   <th:block th:fragment="content">
     <div class="content">


### PR DESCRIPTION
作者你好，很喜欢你的主题，我发现现在主题有个问题是标题对于文章也好还是标签也好都是固定的标题，没有根据对应的文章标题或者标签名称动态标题，导致被浏览器引擎检索的的标题都一样，固我参考了一下halo-dev/theme-earth的方式并将他的I18n拿了过来。特此修改了一下。